### PR TITLE
Add default for getting metadata to get_last_download

### DIFF
--- a/R/download_eden.R
+++ b/R/download_eden.R
@@ -57,7 +57,8 @@ get_data_urls <- function(file_names) {
 #' @export
 #'
 get_last_download <- function(eden_path = file.path("Water"),
-                              metadata, force_update = FALSE) {
+                              metadata = get_metadata(),
+                              force_update = FALSE) {
   if ("last_download.csv" %in% list.files(eden_path) & !force_update) {
     last_download <- read.csv(file.path(eden_path, "last_download.csv")) |>
       dplyr::mutate(last_modified = as.POSIXct(last_modified))


### PR DESCRIPTION
Previously the first argument had a default, but the second argument (metadata) didn't. This caused an error when it was run in get_water_data without any arguments.

This causes an error when running get_eden_data due to: